### PR TITLE
v1.8.4:

### DIFF
--- a/cef/CustomEditField/CustomEditField.rbbas
+++ b/cef/CustomEditField/CustomEditField.rbbas
@@ -461,7 +461,13 @@ Implements MessageReceiver
 	#tag MenuHandler
 		Function EditCut() As Boolean Handles EditCut.Action
 			dim c as new Clipboard
+			
+			#if EditFieldGlobals.Replace00With01
 			c.Text = me.SelText.ReplaceAll (Chr(1), Chr(0))
+			#else
+			c.Text = me.SelText
+			#endif
+			
 			me.SelText = ""
 			Redraw
 			Return true
@@ -513,7 +519,7 @@ Implements MessageReceiver
 		Protected Sub AutocompleteEOL()
 		  //get Autocomplete options from client window
 		  call fetchAutocompleteOptions
-		  if  CurrentAutocompleteOptions = nil then Return //nothing to autocomplete.
+		  if CurrentAutocompleteOptions = nil then Return //nothing to autocomplete.
 		  
 		  dim maxIndex as Integer = UBound(CurrentAutocompleteOptions.Options)
 		  dim firstMatch, longestCommonPrefix, currentPathComponent as String
@@ -568,7 +574,7 @@ Implements MessageReceiver
 		  //get all Autocomplete options for word
 		  
 		  call fetchAutocompleteOptions
-		  if  CurrentAutocompleteOptions = nil then Return //nothing to autocomplete
+		  if CurrentAutocompleteOptions = nil then Return //nothing to autocomplete
 		  if ubound(CurrentAutocompleteOptions.Options) < 0 then Return
 		  
 		  //find XY pos of caret
@@ -1026,11 +1032,7 @@ Implements MessageReceiver
 		  dim doubleClickTime, currentClickTicks as Integer
 		  
 		  #if targetMacOS then
-		    #if targetCarbon or TargetCocoa then
-		      Declare Function GetDblTime Lib "Carbon" () as Integer
-		    #else
-		      Declare Function GetDblTime Lib "InterfaceLib" () as Integer Inline68K("2EB802F0")
-		    #endif
+		    Declare Function GetDblTime Lib "Carbon" () as Integer
 		    doubleClickTime = GetDblTime()
 		    if doubleClickTime <= 0 then
 		      doubleClickTime = 30
@@ -1083,11 +1085,7 @@ Implements MessageReceiver
 		    dim doubleClickTime, currentClickTicks as Integer
 		    
 		    #if targetMacOS then
-		      #if targetCarbon or TargetCocoa then
-		        Declare Function GetDblTime Lib "Carbon" () as Integer
-		      #else
-		        Declare Function GetDblTime Lib "InterfaceLib" () as Integer Inline68K("2EB802F0")
-		      #endif
+		      Declare Function GetDblTime Lib "Carbon" () as Integer
 		      doubleClickTime = GetDblTime()
 		    #endif
 		    
@@ -1191,8 +1189,12 @@ Implements MessageReceiver
 		Sub Copy()
 		  if SelLength = 0 then Return
 		  dim c as new Clipboard
-		  c.Text = me.SelText.ReplaceAll (Chr(1), Chr(0))
 		  
+		  #if EditFieldGlobals.Replace00With01
+		    c.Text = me.SelText.ReplaceAll (Chr(1), Chr(0))
+		  #else
+		    c.Text = me.SelText
+		  #endif
 		End Sub
 	#tag EndMethod
 
@@ -3414,7 +3416,9 @@ Implements MessageReceiver
 		    t = LTrimLines(t)
 		  end
 		  
-		  t = t.ReplaceAll (Chr(0), Chr(1))
+		  #if EditFieldGlobals.Replace00With01
+		    t = t.ReplaceAll (Chr(0), Chr(1))
+		  #endif
 		  
 		  me.SelText = t
 		  

--- a/cef/CustomEditField/CustomScrollableEditField.rbfrm
+++ b/cef/CustomEditField/CustomScrollableEditField.rbfrm
@@ -461,7 +461,7 @@ End
 
 	#tag Method, Flags = &h21
 		Private Function drawFocusRing(ringVisible as Boolean = true, windowGraphics As Graphics) As Boolean
-		  #if TargetMacOS
+		  #if TargetCarbon
 		    
 		    declare function QDBeginCGContext lib "Carbon" (port as Int32, ByRef contextPtr as Int32) as Integer
 		    declare sub CGContextSynchronize lib "Carbon" (context as Int32)
@@ -482,7 +482,11 @@ End
 		    
 		    // We have to open a new drawing context because otherwise we might get our drawings clipped
 		    // or we might draw into the wrong window
-		    grafPort = windowGraphics.Handle(windowGraphics.HandleTypeCGrafPtr)
+		    dim w as Window = me.Window
+		    while w isA ContainerControl
+		      w = ContainerControl(w).Window
+		    wend
+		    grafPort = w.Graphics.Handle(Graphics.HandleTypeCGrafPtr)
 		    res = QDBeginCGContext (grafPort, context)
 		    if res = 0 then
 		      // Now draw the ring
@@ -501,6 +505,9 @@ End
 		    end
 		    if res <> 0 then break
 		    return res = 0
+		    
+		  #elseif TargetCocoa
+		    
 		    
 		  #else
 		    
@@ -969,10 +976,11 @@ End
 	#tag EndNote
 
 	#tag Note, Name = Showing a Focus Ring
-		
 		As of v.1.8, to show a Focus Ring around the CustomScrollableEditField, you must set the 
-		UseFocusRing property to True, and you must called UpdateFocusRiing from the 
+		UseFocusRing property to True, and you must call UpdateFocusRing from the 
 		parent Window's Paint event with the parent Window's Graphics property.
+		
+		Also, this only works in Mac Carbon builds, not in Cocoa, yet.
 		
 		The Window's Paint event should look something like this:
 		
@@ -1612,10 +1620,7 @@ End
 		Sub GotFocus()
 		  self.mHasFocus = true
 		  GotFocus()
-		  #if RBVersion < 2014.01
-		    //
-		    // I don't really know when Invalidate was introduced
-		    //
+		  #if RBVersion < 2014.01 // I don't really know when Invalidate was introduced
 		    self.TrueWindow.Refresh
 		  #else
 		    self.TrueWindow.Invalidate
@@ -1626,10 +1631,7 @@ End
 	#tag Event
 		Sub LostFocus()
 		  self.mHasFocus = false
-		  #if RBVersion < 2014.01
-		    //
-		    // I don't really know when Invalidate was introduced
-		    //
+		  #if RBVersion < 2014.01 // I don't really know when Invalidate was introduced
 		    self.TrueWindow.Refresh
 		  #else
 		    self.TrueWindow.Invalidate

--- a/cef/CustomEditField/EditFieldGlobals.rbbas
+++ b/cef/CustomEditField/EditFieldGlobals.rbbas
@@ -94,13 +94,16 @@ Protected Module EditFieldGlobals
 	#tag EndProperty
 
 
-	#tag Constant, Name = CEF_VERSION, Type = String, Dynamic = False, Default = \"1.8.3", Scope = Protected
+	#tag Constant, Name = CEF_VERSION, Type = String, Dynamic = False, Default = \"1.8.4", Scope = Protected
 	#tag EndConstant
 
 	#tag Constant, Name = DebugIndentation, Type = Boolean, Dynamic = False, Default = \"false", Scope = Protected
 	#tag EndConstant
 
 	#tag Constant, Name = DebugTiming, Type = Boolean, Dynamic = False, Default = \"false", Scope = Protected
+	#tag EndConstant
+
+	#tag Constant, Name = Replace00With01, Type = Boolean, Dynamic = False, Default = \"true", Scope = Protected
 	#tag EndConstant
 
 	#tag Constant, Name = STORAGE_ARRAY, Type = Double, Dynamic = False, Default = \"1", Scope = Protected

--- a/cef/CustomEditField/LineManager/LineManager.rbbas
+++ b/cef/CustomEditField/LineManager/LineManager.rbbas
@@ -274,6 +274,9 @@ Class LineManager
 	#tag Method, Flags = &h1
 		Protected Sub fixOffsets(lineNumber as integer, startOffset as integer)
 		  //fix all the offsets starting at the given line number, with the given offset
+		  
+		  #pragma DisableBackgroundTasks
+		  
 		  dim maxIndex as Integer = UBound(lines)
 		  dim line as TextLine
 		  

--- a/cef/CustomEditField/LineManager/TextLine.rbbas
+++ b/cef/CustomEditField/LineManager/TextLine.rbbas
@@ -276,8 +276,12 @@ Inherits TextSegment
 		      end if
 		      text = storage.getText(selfWordOfs, word.length)
 		      
-		      // convert Chr(1), which we use for original NUL chars, to a "NUL" character for display
-		      text = text.ReplaceAll (Chr(1), "␀")
+		      #if EditFieldGlobals.Replace00With01
+		        // convert Chr(1), which we use for original NUL chars, to a "NUL" character for display
+		        text = text.ReplaceAll (Chr(1), "␀")
+		      #else
+		        text = text.ReplaceAll (Chr(0), "␀")
+		      #endif
 		    end if
 		    
 		    g.Bold = Word.bold or bold

--- a/cef/DemoWindow.rbfrm
+++ b/cef/DemoWindow.rbfrm
@@ -1970,6 +1970,7 @@ End
 		  
 		  TestField.ReindentText // cleans up indentations, removing any leading blanks from the lines
 		  TestField.ResetUndo // needed so that the Reindentation doesn't become an undoable action
+		  SetWindowModified(false)
 		  
 		  // Add a few row icons at random lines.
 		  testField.LineIcon(rnd * testField.MaxVisibleLines) = rowicondata


### PR DESCRIPTION
- Adds a constant to disable the automatic Chr(0)-to-Chr(1) replacement.
- Disables the drawFocusRing code for TargetCocoa because it doesn't work there.
- Clears the "WindowModified" flag after indenting the text in DemoWindow.Open().